### PR TITLE
docs: add sponsors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ body: |
 
 That's it! No complex setup required. The project is designed to be as simple as possible to encourage contributions.
 
+<!-- automd:fetch url="gh:hugorcd/markdown/main/src/sponsors.md" -->
+
+## Sponsors
+
+<p align="center">
+  <a href="https://github.com/sponsors/HugoRCD">
+    <img src='https://cdn.jsdelivr.net/gh/hugorcd/static/sponsors.svg' alt="HugoRCD sponsors" />
+  </a>
+</p>
+
+<!-- /automd -->
+
 <!-- automd:contributors license=Apache author=HugoRCD github="hugorcd/nuppets" -->
 
 Published under the [APACHE](https://github.com/hugorcd/nuppets/blob/main/LICENSE) license.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### 🔗 Linked issue

N/A — README alignment with other HugoRCD OSS repos.

### 📚 Description

Adds the shared automd Sponsors block to the root `README.md`, inserted before the contributors automd section. This matches the pattern used in shelve, canvas, and nuxt-visitors.

The rest of the README is unchanged.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4822fb0-0433-4b1c-9b5b-0dbf04e2797f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4822fb0-0433-4b1c-9b5b-0dbf04e2797f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Sponsors section to the README, including a GitHub sponsors image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->